### PR TITLE
Make CAS sample code more readable.

### DIFF
--- a/lectures/L20.tex
+++ b/lectures/L20.tex
@@ -276,16 +276,16 @@ Afterwards, you can check if the CAS returned {\tt oldval}. If it did, you know 
 \paragraph{Implementing a Spinlock.}
 You can use compare-and-swap to implement spinlock:
   \begin{lstlisting}
-void spinlock_init(int* l) { *l = 0; }
+void spinlock_init(int* lock) { *lock = 0; }
 
-void spinlock_lock(int* l) {
-    while(compare_and_swap(l, 0, 1) != 0) {}
+void spinlock_lock(int* lock) {
+    while(compare_and_swap(lock, 0, 1) != 0) {}
     __asm__ ("mfence");
 }
 
-void spinlock_unlock(int* int) {
+void spinlock_unlock(int* lock) {
     __asm__ ("mfence");
-    *l = 0;  
+    *lock = 0;  
 }
   \end{lstlisting}
 You'll see {\bf cmpxchg} quite frequently in the Linux kernel code.


### PR DESCRIPTION
Fixed typo "int int" should be "int l".

Update variable name to be easier to read; "l" and "1" are very similar. "s/l/lock/g".
